### PR TITLE
Using prefix increment instead of suffix one for iterators

### DIFF
--- a/Windows/debugger.cpp
+++ b/Windows/debugger.cpp
@@ -43,7 +43,7 @@ limitations under the License.
 // cleans up all breakpoint structures
 // does not actually remove breakpoints in target process 
 void Debugger::DeleteBreakpoints() {
-  for (auto iter = breakpoints.begin(); iter != breakpoints.end(); iter++) {
+  for (auto iter = breakpoints.begin(); iter != breakpoints.end(); ++iter) {
     delete *iter;
   }
   breakpoints.clear();

--- a/tinyinst.cpp
+++ b/tinyinst.cpp
@@ -138,7 +138,7 @@ TinyInst::ModuleInfo::ModuleInfo() {
 void TinyInst::ModuleInfo::ClearInstrumentation() {
   instrumented = false;
 
-  for (auto iter = executable_ranges.begin(); iter != executable_ranges.end(); iter++) {
+  for (auto iter = executable_ranges.begin(); iter != executable_ranges.end(); ++iter) {
     if (iter->data) free(iter->data);
   }
   executable_ranges.clear();


### PR DESCRIPTION
Hello,

This is a minor fix: using prefix increment for iterators would give [better performance](https://stackoverflow.com/questions/24901/is-there-a-performance-difference-between-i-and-i-in-c) than suffix one.

There exist also several places in the code where this fix can be applied.