### PR TITLE
Fixed compilation bug on macOS

### DIFF
--- a/macOS/debugger.cpp
+++ b/macOS/debugger.cpp
@@ -79,7 +79,7 @@ void Debugger::ClearSharedMemory() {
 std::list<SharedMemory>::iterator Debugger::FreeSharedMemory(std::list<SharedMemory>::iterator it) {
   if (it->size == 0) {
     WARN("FreeShare is called with size == 0\n");
-    return;
+    return ++it;
   }
 
   kern_return_t krt = mach_port_destroy(mach_task_self(), it->port);


### PR DESCRIPTION
fixes - https://github.com/googleprojectzero/TinyInst/issues/20

I'm also adding a sanity build support for TinyInst, this doesn't create build artifacts (we had this discussion on WinAFL).
But it will make sure that this project continues to build on all platforms (2 macOS versions & windows-2019)

