### PR TITLE
add 'SeDebugPrivilege' setup on Attach routine

### DIFF
--- a/Windows/debugger.cpp
+++ b/Windows/debugger.cpp
@@ -1536,8 +1536,35 @@ DebuggerStatus Debugger::Attach(unsigned int pid, uint32_t timeout) {
   attach_mode = true;
 
   if (!DebugActiveProcess(pid)) {
-    FATAL("Could not attach to the process.\n"
-          "Make sure the process exists and you have permissions to debug it.\n");
+    DWORD error_code = GetLastError();
+    SAY("DebugActiveProcess(%d) failed with error code = %d\n", error_code);
+
+    if(error_code == 5) {
+      HANDLE hToken = NULL;
+      LUID luid;
+      TOKEN_PRIVILEGES tp;
+      SAY("Try again after enabling 'SeDebugPrivilege'\n");
+
+      if(OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &hToken)) {
+        if(LookupPrivilegeValueA(NULL, "SeDebugPrivilege", &luid)) {
+          tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
+          tp.Privileges[0].Luid = luid;
+          tp.PrivilegeCount = 1;
+          if(AdjustTokenPrivileges(hToken, FALSE, &tp, sizeof(TOKEN_PRIVILEGES), NULL, NULL)) {
+            if(!DebugActiveProcess(pid)) {
+              FATAL("Could not attach to the process.\n"
+              "Make sure the process exists and you have permissions to debug it.\n");
+            }
+          } else {
+            FATAL("AdjustTokenPrivileges() failed, error code = %d\n", GetLastError());
+          }
+        } else {
+          FATAL("LookupPrivilegeValueA() failed, error code = %d\n", GetLastError());
+        }
+      } else {
+        FATAL("OpenProcessToken() failed, error code = %d\n", GetLastError());
+      }
+    }
   }
 
   dbg_last_status = DEBUGGER_ATTACHED;


### PR DESCRIPTION
If `DebugActiveProcess` 's error options is `5( =ERROR_ACCESS_DENIED )`, most of my cases were due to `SeDebugPrilege` didn't setup. So I add this.