### PR TITLE
Add Support Functions for Fuzzing Attached Processes and Fix a False Hang issue in attached processes

### DIFF
--- a/Windows/debugger.h
+++ b/Windows/debugger.h
@@ -77,7 +77,11 @@ public:
     return last_exception;
   }
 
+  char * script;
+
 protected:
+
+  DWORD processID;
 
   enum MemoryProtection {
     READONLY,

--- a/common.cpp
+++ b/common.cpp
@@ -20,6 +20,12 @@ limitations under the License.
 #include <chrono>
 
 #include "common.h"
+#include <windows.h>
+#include <tlhelp32.h>
+#include <iostream>
+#include <string>
+#include <codecvt>
+#include <locale> 
 
 uint64_t GetCurTime(void) {
   auto duration =  std::chrono::system_clock::now().time_since_epoch();
@@ -96,6 +102,25 @@ int GetIntOption(const char *name, int argc, char** argv, int default_value) {
   return (int)strtol(option, NULL, 0);
 }
 
+DWORD FindProcessId(char * process_name)
+{
+    PROCESSENTRY32 entry;
+    entry.dwSize = sizeof(PROCESSENTRY32);
+
+    HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, NULL);
+
+    if (Process32First(snapshot, &entry) == TRUE)
+    {
+        while (Process32Next(snapshot, &entry) == TRUE)
+        {
+            if (stricmp(entry.szExeFile, process_name) == 0)
+            {  
+              CloseHandle(snapshot);
+                return entry.th32ProcessID;
+            }
+        }
+    }
+}
 
 //quoting on Windows is weird
 size_t ArgvEscapeWindows(char *in, char *out) {

--- a/common.h
+++ b/common.h
@@ -75,6 +75,7 @@ uint64_t GetCurTime(void);
 char *GetOption(const char *name, int argc, char** argv);
 void GetOptionAll(const char *name, int argc, char** argv, std::list<char *> *results);
 bool GetBinaryOption(const char *name, int argc, char** argv, bool default_value);
+DWORD FindProcessId(char * process_name);
 int GetIntOption(const char *name, int argc, char** argv, int default_value);
 
 char *ArgvToCmd(int argc, char** argv);


### PR DESCRIPTION
To add [support](https://github.com/googleprojectzero/Jackalope/pull/38) to Jackalope for fuzzing attached processes, I needed to add a helper function FindProcessId to common.cpp. The second issue I found was in the function DebugLoop. When getting coverage by attaching to a running process, the DebugLoop would always report a hang because the running process wouldn't exit. For many running processes, the program does not exit event after a testcase is sent to it, so this would result in false hangs (Ex. fuzzing a mail server). 