### PR TITLE
Linux: debug.r_brk function might start with endbr instruction.

### DIFF
--- a/Linux/debugger.cpp
+++ b/Linux/debugger.cpp
@@ -1032,7 +1032,15 @@ int Debugger::GetLoadedModulesT(std::set<LoadedModule> &modules, bool set_breakp
   }
 
   if(set_breakpoint) {
-    AddBreakpoint((void *)(uint64_t)debug.r_brk, BREAKPOINT_NOTIFICATION); 
+    uint32_t inst = 0;
+    uint32_t endbr32 = 0xfb1e0ff3;
+    uint32_t endbr64 = 0xfa1e0ff3;
+    RemoteRead((void *)debug.r_brk, &inst, sizeof(inst));
+    if ((child_ptr_size == 4 && inst == endbr32) || (child_ptr_size == 8 && inst == endbr64)) {
+      AddBreakpoint((void *)((uint64_t)debug.r_brk + sizeof(inst)), BREAKPOINT_NOTIFICATION);
+    } else {
+      AddBreakpoint((void *)(uint64_t)debug.r_brk, BREAKPOINT_NOTIFICATION);
+    }
   }
 
   return 1;

--- a/Linux/debugger.cpp
+++ b/Linux/debugger.cpp
@@ -1032,6 +1032,9 @@ int Debugger::GetLoadedModulesT(std::set<LoadedModule> &modules, bool set_breakp
   }
 
   if(set_breakpoint) {
+#ifdef ARM64
+    AddBreakpoint((void *)(uint64_t)debug.r_brk, BREAKPOINT_NOTIFICATION);
+#else
     uint32_t inst = 0;
     uint32_t endbr32 = 0xfb1e0ff3;
     uint32_t endbr64 = 0xfa1e0ff3;
@@ -1041,6 +1044,7 @@ int Debugger::GetLoadedModulesT(std::set<LoadedModule> &modules, bool set_breakp
     } else {
       AddBreakpoint((void *)(uint64_t)debug.r_brk, BREAKPOINT_NOTIFICATION);
     }
+#endif
   }
 
   return 1;


### PR DESCRIPTION
https://github.com/googleprojectzero/TinyInst/issues/70