### PR TITLE
(windows) Fixing RestoreRegisters() save register status to lcContext

### DIFF
--- a/Windows/debugger.cpp
+++ b/Windows/debugger.cpp
@@ -97,6 +97,8 @@ void Debugger::SaveRegisters(SavedRegisters* registers) {
 
 void Debugger::RestoreRegisters(SavedRegisters* registers) {
   have_thread_context = false;
+  memcpy(&lcContext, &registers->saved_context, sizeof(registers->saved_context));
+
   HANDLE thread_handle = OpenThread(THREAD_ALL_ACCESS, FALSE, thread_id);
   if (!SetThreadContext(thread_handle, &lcContext)) {
     FATAL("Error restoring registers");


### PR DESCRIPTION
Hello, a bug fix for the windows platform,

In windows/debugger.cpp#RestoreRegisters(), the target thread context should be restored using the passed register value;

When target program is a multi-threaded program. Using the following command can trigger bugs with a higher probability:

`litecov.exe -instrument_module [module] -target_module [module] -target_method [method] -generate_unwind --[harness.exe]`

When the bug is triggered, TinyInst usually receives a 0xC0000005 (access violation) exception from the target program; TinyInst treats this as a crash in the target program.

After further testing and analysis, I think that the bug will not be triggered in a single-threaded target program or when `-generate_unwind` is not used; In addition, in a multi-threaded target program, with `-generate_unwind` and without `-target_module/-target_method`, the bug will (maybe) not be triggered (TinyInst will complete instrumentation at the program entry, and this moment can be regarded as single-threaded Case?)

PS: macOS uses a similar implementation, but I think there is no problem with macOS’s implementation.

