### PR TITLE
Updated README to include submodule initialization before build

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ According to early measurements on image decoding, on a well-behaving 64-bit tar
 
 2. Navigate to the directory containing the source
 
-3. Run the following commands (change the generator according to the version of IDE and platform you want to build for):
+3. Initialize submodules (run `git submodule update --init --recursive`)
+
+4. Run the following commands (change the generator according to the version of IDE and platform you want to build for):
 
 #### Windows
 ```


### PR DESCRIPTION
Updated the readme to prompt users to initialize submodules before building to avoid compilation issues.

![image](https://github.com/googleprojectzero/TinyInst/assets/49928773/586323e1-937a-462c-a9b3-7756501b488c)
