### PR TITLE
Fix clang compilation issue

### DIFF
--- a/arch/arm64/arm64_helpers.cpp
+++ b/arch/arm64/arm64_helpers.cpp
@@ -166,7 +166,7 @@ uint32_t br(Register dst_reg) {
 }
 
 uint32_t b_cond(const std::string &cond, int32_t off) {
-  static const std::vector<const std::string> condition_codes = {
+  static const std::vector<std::string> condition_codes = {
       "eq", "ne", "cs", "cc", "mi", "pl", "vs", "vc",
       "hi", "ls", "ge", "lt", "gt", "le", "al", "al"
   };


### PR DESCRIPTION
Fix for build issues with homebrew clang-19:
```
/opt/homebrew/Cellar/llvm/19.1.4/bin/../include/c++/v1/__memory/allocator.h:95:17: error: static assertion failed due to requirement '!is_const<const std::string>::value': std::allocator does not support const types
   95 |   static_assert(!is_const<_Tp>::value, "std::allocator does not support const types");
      |                 ^~~~~~~~~~~~~~~~~~~~~
```

You can find description of the problem here: https://stackoverflow.com/questions/21365331/which-is-correct-vectorconst-string-or-const-vectorstring