### PR TITLE
fix hook support for Jackalope

### DIFF
--- a/arch/arm64/arm64_litecov.cpp
+++ b/arch/arm64/arm64_litecov.cpp
@@ -90,6 +90,10 @@ InstructionResult LiteCov::InstrumentInstruction(ModuleInfo *module,
                                                  Instruction &inst,
                                                  size_t bb_address,
                                                  size_t instruction_address) {
+  
+  InstructionResult tinyinst_ret = TinyInst::InstrumentInstruction(module, inst, bb_address, instruction_address);
+  if(tinyinst_ret != INST_NOTHANDLED) return tinyinst_ret;
+
   if (!compare_coverage) {
     return INST_NOTHANDLED;
   }

--- a/arch/x86/x86_litecov.cpp
+++ b/arch/x86/x86_litecov.cpp
@@ -154,6 +154,10 @@ InstructionResult LiteCov::InstrumentInstruction(ModuleInfo *module,
                                                  Instruction &inst,
                                                  size_t bb_address,
                                                  size_t instruction_address) {
+
+  InstructionResult tinyinst_ret = TinyInst::InstrumentInstruction(module, inst, bb_address, instruction_address);
+  if(tinyinst_ret != INST_NOTHANDLED) return tinyinst_ret;
+  
   if (!compare_coverage) {
     return INST_NOTHANDLED;
   }


### PR DESCRIPTION
- Fixes Hook API when built into the Jackalope, which allows users to apply hooks that run during fuzzing