### PR TITLE
Use the cross-compilation tool to generate arm64 litecov.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,9 +28,9 @@ elseif(NOT DEFINED ${ARCHITECTURE})
   endif()
 endif()
 
-add_subdirectory(third_party)
-
 project("tinyinst")
+
+add_subdirectory(third_party)
 
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/third_party/obj/wkit/include)
 

--- a/Linux/arm64.toochain.cmake
+++ b/Linux/arm64.toochain.cmake
@@ -1,0 +1,12 @@
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+
+set(ARCHITECTURE arm64)
+add_definitions(-DARM64)
+
+# search for programs in the build host directories.
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# Only look for libraries, headers and packages in the sysroot, don't look on the build machine.
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)

--- a/Linux/debugger.h
+++ b/Linux/debugger.h
@@ -81,6 +81,7 @@ struct LoadedModule {
 bool operator< (LoadedModule const& lhs, LoadedModule const& rhs);
 
 #ifdef ARM64
+#include <asm/ptrace.h>
 typedef user_pt_regs arch_reg_struct;
 #else
 typedef user_regs_struct arch_reg_struct;

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ cmake -DCMAKE_TOOLCHAIN_FILE=</path/to/android/ndk>build/cmake/android.toolchain
 cmake --build . --config Release
 ```
 
+#### Cross-compiling for Linux
+```
+mkdir build
+cd build
+cmake -DCMAKE_TOOLCHAIN_FILE=../Linux/arm64.toochain.cmake ..
+cmake --build . --config Release
+```
+
 Note #1: 64-bit build will also run against 32-bit targets on Windows and Linux operating systems
 
 Note #2: Encountering problems creating a 32-bit build on 64-bit Windows due to the environment not being properly set up and libraries missing? Open the generated .sln file in Visual Studio and build from there instead of running cmake --build. Also note that 64-bit build is going to work on 32-bit targets, so creating a 32-bit build might not be necessary.


### PR DESCRIPTION
This PR allows us to generate arm64 litecov in an x86 Linux environment using cross-compilation tools. The advantage of using cross-compilation is that you can generate Tinyinst binaries that can be used by Android or other arm64 systems without the need for Android NDK.

Tip: Of course, in this environment, when compiling, we often need to generate a statically linked binary. Therefore, please add the build option `-DCMAKE_EXE_LINKER_FLAGS=-static`